### PR TITLE
feat: add upload handler for Figma image downloads

### DIFF
--- a/src/services/figma.ts
+++ b/src/services/figma.ts
@@ -5,7 +5,8 @@ import type {
   GetFileNodesResponse,
   GetImageFillsResponse,
 } from "@figma/rest-api-spec";
-import { downloadFigmaImage } from "~/utils/common.js";
+import type { WriteStream } from "fs";
+import { PassThrough } from "stream";
 import { downloadAndProcessImage, type ImageProcessingResult } from "~/utils/image-processing.js";
 import { Logger, writeLogs } from "~/utils/logger.js";
 import { fetchWithRetry } from "~/utils/fetch-with-retry.js";
@@ -150,6 +151,7 @@ export class FigmaService {
       requiresImageDimensions?: boolean;
     }>,
     options: { pngScale?: number; svgOptions?: SvgOptions } = {},
+    upload?: (writer: WriteStream | PassThrough, fullPath: string) => unknown | Promise<unknown>,
   ): Promise<ImageProcessingResult[]> {
     if (items.length === 0) return [];
     
@@ -184,6 +186,7 @@ export class FigmaService {
                 needsCropping,
                 cropTransform,
                 requiresImageDimensions,
+                upload,
               )
             : null;
         })
@@ -218,6 +221,7 @@ export class FigmaService {
                   needsCropping,
                   cropTransform,
                   requiresImageDimensions,
+                  upload,
                 )
               : null;
           })
@@ -247,6 +251,7 @@ export class FigmaService {
                   needsCropping,
                   cropTransform,
                   requiresImageDimensions,
+                  upload,
                 )
               : null;
           })

--- a/src/tools/download-figma-images.ts
+++ b/src/tools/download-figma-images.ts
@@ -1,6 +1,8 @@
 import { z } from "zod";
 import { FigmaService } from "../services/figma.js";
 import { Logger } from "../utils/logger.js";
+import type { WriteStream } from "fs";
+import { PassThrough } from "stream";
 
 const parameters = {
   fileKey: z
@@ -68,6 +70,7 @@ export type DownloadImagesParams = z.infer<typeof downloadFigmaImagesSchema>;
 export async function downloadFigmaImages(
   params: DownloadImagesParams,
   figmaService: FigmaService,
+  upload?: (writer: WriteStream | PassThrough, fullPath: string) => unknown | Promise<unknown>,
 ) {
   try {
     const { fileKey, nodes, localPath, pngScale = 2 } = params;
@@ -124,9 +127,15 @@ export async function downloadFigmaImages(
       }
     }
 
-    const allDownloads = await figmaService.downloadImages(fileKey, localPath, downloadItems, {
-      pngScale,
-    });
+    const allDownloads = await figmaService.downloadImages(
+      fileKey,
+      localPath,
+      downloadItems,
+      {
+        pngScale,
+      },
+      upload,
+    );
 
     const successCount = allDownloads.filter(Boolean).length;
 

--- a/src/utils/image-processing.ts
+++ b/src/utils/image-processing.ts
@@ -1,6 +1,7 @@
 import fs from "fs";
 import sharp from "sharp";
 import type { Transform } from "@figma/rest-api-spec";
+import { PassThrough } from "stream";
 
 /**
  * Apply crop transform to an image based on Figma's transformation matrix
@@ -135,13 +136,14 @@ export async function downloadAndProcessImage(
   needsCropping: boolean = false,
   cropTransform?: Transform,
   requiresImageDimensions: boolean = false,
+  upload?: (writer: fs.WriteStream | PassThrough, fullPath: string) => unknown | Promise<unknown>,
 ): Promise<ImageProcessingResult> {
   const { Logger } = await import("./logger.js");
   const processingLog: string[] = [];
 
   // First download the original image
   const { downloadFigmaImage } = await import("./common.js");
-  const originalPath = await downloadFigmaImage(fileName, localPath, imageUrl);
+  const originalPath = await downloadFigmaImage(fileName, localPath, imageUrl, upload);
   Logger.log(`Downloaded original image: ${originalPath}`);
 
   // Get original dimensions before any processing


### PR DESCRIPTION
## Summary
- allow `downloadFigmaImage` to delegate writing via optional `upload` handler
- thread optional upload callback through image processing and service layers
- support custom upload in `downloadFigmaImages` tool

## Testing
- `npm test`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68bcd6cfb5dc832daa4dc5c3918b50f4