### PR TITLE
feat: return image list from downloadFigmaImages

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export { downloadFigmaImages } from "./tools/download-figma-images.js";
-export type { DownloadImagesParams } from "./tools/download-figma-images.js";
+export type { DownloadImagesParams, DownloadedImage } from "./tools/download-figma-images.js";
 export { getFigmaData } from "./tools/get-figma-data.js";
 export type { GetFigmaDataParams } from "./tools/get-figma-data.js";
 export { FigmaService } from "./services/figma.js";

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,4 +1,4 @@
 export { downloadFigmaImages } from "./download-figma-images.js";
-export type { DownloadImagesParams } from "./download-figma-images.js";
+export type { DownloadImagesParams, DownloadedImage } from "./download-figma-images.js";
 export { getFigmaData } from "./get-figma-data.js";
 export type { GetFigmaDataParams } from "./get-figma-data.js";


### PR DESCRIPTION
## Summary
- expose `DownloadedImage` type
- refactor `downloadFigmaImages` to return an array of nodeId to file path mappings

## Testing
- `pnpm test`
- `pnpm lint` *(fails: Missing return type on function, Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7c234848832db1a5aa1a021ad7c1